### PR TITLE
feat(securty): permitir acceso publico a imagenes de productos

### DIFF
--- a/src/main/java/com/thekingmoss/security/SecurityConfig.java
+++ b/src/main/java/com/thekingmoss/security/SecurityConfig.java
@@ -73,8 +73,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/direccion/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_USER")
                         .requestMatchers(HttpMethod.DELETE, "/api/direccion/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_USER")
                         //Producto Imagen
-                        .requestMatchers(HttpMethod.GET, "/api/productoImagen").hasAuthority("ROLE_ADMIN")
-                        .requestMatchers(HttpMethod.GET, "/api/productoImagen/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_USER")
+                        .requestMatchers(HttpMethod.GET, "/api/productoImagen").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/productoImagen/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/productoImagen").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/productoImagen/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/productoImagen/**").hasAuthority("ROLE_ADMIN")


### PR DESCRIPTION
- Modifique el SecurityConfig para permitir acceso sin autenticación a endpoints de imágenes
- Ahora cualquier usuario (logueado o no) puede ver las imágenes de productos
- Rutas actualizadas:
  - GET /api/productoImagen → permitAll()
  - GET /api/productoImagen/** → permitAll()
- Operaciones de escritura (POST, PUT, DELETE) siguen restringidas a ROLE_ADMIN
- Esto permite que el frontend muestre imágenes en la tienda sin requerir login